### PR TITLE
Fix error where it can't find http#get()

### DIFF
--- a/autoload/unite/sources/boost_online_doc.vim
+++ b/autoload/unite/sources/boost_online_doc.vim
@@ -17,7 +17,7 @@ function! s:get_libraries_url(version)
 	
 	if a:version == "trunk"
 		let boost_url = "http://svn.boost.org/svn/boost/trunk/libs/"
-		let text = http#get("http://svn.boost.org/svn/boost/trunk/libs/libraries.htm").content
+		let text = webapi#http#get("http://svn.boost.org/svn/boost/trunk/libs/libraries.htm").content
 		let list = split(matchstr(text, '<ul>\zs.*\ze<\/ul>'), "\n")
 		
 		for line in list
@@ -30,7 +30,7 @@ function! s:get_libraries_url(version)
 		endfor
 	else
 		let boost_url = "http://www.boost.org/doc/libs/"
-		let text = http#get("http://www.boost.org/doc/libs/".a:version."/").content
+		let text = webapi#http#get("http://www.boost.org/doc/libs/".a:version."/").content
 		let list = split(text, "\n")
 		for line in list
 			let url  = matchstr(line, '<dt><a href="/doc/libs/\zs.*\ze/">')


### PR DESCRIPTION
mattn/webapi-vimを見ると関数名が`webapi#http#get()`に変更されたみたいなので、直しておきました。
